### PR TITLE
Support more distortion parameters

### DIFF
--- a/geocalib/geocalib.py
+++ b/geocalib/geocalib.py
@@ -112,7 +112,7 @@ class GeoCalib(nn.Module):
 
         out |= {
             k: data[k]
-            for k in ["image", "scales", "prior_gravity", "prior_focal", "prior_k1"]
+            for k in ["image", "scales", "prior_gravity", "prior_focal", "prior_dist"]
             if k in data
         }
 

--- a/geocalib/lm_optimizer.py
+++ b/geocalib/lm_optimizer.py
@@ -45,7 +45,7 @@ def get_trivial_estimation(data: Dict[str, torch.Tensor], camera_model: BaseCame
 
     params = {"width": batch_w, "height": batch_h, "vfov": init_vfov}
     params |= {"scales": data["scales"]} if "scales" in data else {}
-    params |= {"k1": data["prior_k1"]} if "prior_k1" in data else {}
+    params |= {"dist": data["prior_dist"]} if "prior_dist" in data else {}
     camera = camera_model.from_dict(params)
     camera = camera.float().to(ref.device)
 
@@ -216,21 +216,24 @@ class LMOptimizer(nn.Module):
             self.estimate_focal = False
             logger.debug("Using provided focal as prior.")
 
-        self.estimate_k1 = True
-        if "prior_k1" in data:
-            self.estimate_k1 = False
-            logger.debug("Using provided k1 as prior.")
+        self.estimate_dist = self.camera_model.name() in ["radial", "simple_radial", "simple_divisional"]
+        if "prior_dist" in data:
+            self.estimate_dist = False
+            logger.debug("Using provided distortion as prior.")
 
         self.gravity_delta_dims = (0, 1) if self.estimate_gravity else (-1,)
         self.focal_delta_dims = (
             (max(self.gravity_delta_dims) + 1,) if self.estimate_focal else (-1,)
         )
-        self.k1_delta_dims = (max(self.focal_delta_dims) + 1,) if self.estimate_k1 else (-1,)
+        
+        self.dist_delta_dims = None
+        if self.estimate_dist:
+            self.dist_delta_dims = tuple(range(self.focal_delta_dims[-1] + 1, self.focal_delta_dims[-1] + 1 + self.camera_model.num_dist_params()))
 
-        logger.debug(f"Camera Model:       {self.camera_model}")
-        logger.debug(f"Optimizing gravity: {self.estimate_gravity} ({self.gravity_delta_dims})")
-        logger.debug(f"Optimizing focal:   {self.estimate_focal} ({self.focal_delta_dims})")
-        logger.debug(f"Optimizing k1:      {self.estimate_k1} ({self.k1_delta_dims})")
+        logger.debug(f"Camera Model:         {self.camera_model}")
+        logger.debug(f"Optimizing gravity:   {self.estimate_gravity} ({self.gravity_delta_dims})")
+        logger.debug(f"Optimizing focal:     {self.estimate_focal} ({self.focal_delta_dims})")
+        logger.debug(f"Optimizing distortion:{self.estimate_dist} ({self.dist_delta_dims})")
 
         logger.debug(f"Shared intrinsics:  {self.shared_intrinsics}")
 
@@ -326,8 +329,8 @@ class LMOptimizer(nn.Module):
             dims = (0, 1)
         if self.estimate_focal:
             dims += (2,)
-        if self.camera_has_distortion and self.estimate_k1:
-            dims += (3,)
+        if self.camera_has_distortion:
+            dims += tuple(range(3, 3 + self.camera_model.num_dist_params()))
         assert dims, "No parameters to optimize"
 
         J = J[..., dims]
@@ -398,7 +401,7 @@ class LMOptimizer(nn.Module):
         n_params = (
             2 * self.estimate_gravity
             + self.estimate_focal
-            + (self.camera_has_distortion and self.estimate_k1)
+            + (self.camera_model.num_dist_params() if self.camera_has_distortion else 0)
         )
         Grad = J_up.new_zeros(J_up.shape[0], n_params)
         Hess = J_up.new_zeros(J_up.shape[0], n_params, n_params)
@@ -517,12 +520,8 @@ class LMOptimizer(nn.Module):
         )
         new_camera = camera.update_focal(delta_f, as_log=self.conf.use_log_focal)
 
-        delta_dist = (
-            delta[..., self.k1_delta_dims]
-            if self.camera_has_distortion and self.estimate_k1
-            else delta.new_zeros(delta.shape[:-1] + (1,))
-        )
-        if self.camera_has_distortion:
+        if self.camera_has_distortion and self.estimate_dist:
+            delta_dist = delta[..., self.dist_delta_dims]
             new_camera = new_camera.update_dist(delta_dist)
 
         return new_camera, new_gravity

--- a/geocalib/perspective_fields.py
+++ b/geocalib/perspective_fields.py
@@ -118,7 +118,7 @@ def J_up_field(
     # distortion values
     if hasattr(camera, "dist"):
         d_uv = camera.distort(uv, return_scale=True)[0]  # (..., N, 1)
-        d_uv = torch.diag_embed(d_uv.expand(d_uv.shape[:-1] + (2,)))  # (..., N, 2, 2)
+        d_uv_diag = torch.diag_embed(d_uv.expand(d_uv.shape[:-1] + (2,)))  # (..., N, 2, 2)
         offset = camera.up_projection_offset(uv)  # (..., N, 2)
         offset_uv = torch.einsum("...i,...j->...ij", offset, uv)  # (..., N, 2, 2)
 
@@ -130,7 +130,7 @@ def J_up_field(
 
     if hasattr(camera, "dist"):
         # (..., N, 2, 3)
-        J_proj2abc = torch.einsum("...Nij,...Njk->...Nik", d_uv + offset_uv, J_proj2abc)
+        J_proj2abc = torch.einsum("...Nij,...Njk->...Nik", d_uv_diag + offset_uv, J_proj2abc)
 
     J_abc2delta = SphericalManifold.J_plus(gravity.vec3d) if spherical else gravity.J_rp()
     J_proj2delta = torch.einsum("...Nij,...jk->...Nik", J_proj2abc, J_abc2delta)
@@ -144,7 +144,7 @@ def J_up_field(
     J_proj2uv = J_up_projection(uv, gravity.vec3d, wrt="uv")  # (..., N, 2, 2)
 
     if hasattr(camera, "dist"):
-        J_proj2up = torch.einsum("...Nij,...Njk->...Nik", d_uv + offset_uv, J_proj2uv)
+        J_proj2up = torch.einsum("...Nij,...Njk->...Nik", d_uv_diag + offset_uv, J_proj2uv)
         J_proj2duv = torch.einsum("...i,...j->...ji", offset, projected_up2d)
 
         inner = (uv * projected_up2d).sum(-1)[..., None, None]
@@ -164,18 +164,34 @@ def J_up_field(
     J.append(J_up2f)
 
     ######################
-    ##### K1 Jacobian ####
+    ##### Distortion Parameters Jacobian ####
     ######################
 
     if hasattr(camera, "dist"):
-        J_duv = camera.J_distort(uv, wrt="scale2dist")
-        J_duv = torch.diag_embed(J_duv.expand(J_duv.shape[:-1] + (2,)))  # (..., N, 2, 2)
-        J_offset = torch.einsum(
-            "...i,...j->...ij", camera.J_up_projection_offset(uv, wrt="dist"), uv
-        )
-        J_proj2k1 = torch.einsum("...Nij,...Nj->...Ni", J_duv + J_offset, projected_up2d)
-        J_k1 = torch.einsum("...Nij,...Nj->...Ni", J_norm2proj, J_proj2k1)[..., None]
-        J.append(J_k1)
+        # The following is derived from Eq (9) in the paper.
+
+        # Part 1: x * dy
+        J_offset2dist = camera.J_up_projection_offset(uv, wrt="dist") # (B, N, 2) for k1 only or (B, N, 2, K)
+        if len(J_offset2dist.shape) == len(uv.shape):
+            J_offset2dist = J_offset2dist.unsqueeze(-1) # (B, N, 2, K)
+        uv_J_offset2_dist = torch.einsum("...i,...jk->...ijk", uv, J_offset2dist)  # (B, N, 2, 2, K)
+        uv_J_offset2_dist = uv_J_offset2_dist / d_uv[..., None, None]
+
+        # Part 2: dx * y
+        J_duv = camera.J_distort(uv, wrt="scale2dist")  # (B, N, K)
+        uv_offset = torch.einsum("...i,...j->...ij", uv, offset) # (B, N, 2, 2)
+        # (B, N, 2, 2) x (B, N, K) -> (B, N, 2, 2, K)
+        uv_offset_J_duv = torch.einsum("...ij,...k->...ijk", uv_offset, J_duv)
+        uv_offset_J_duv = - uv_offset_J_duv / d_uv[..., None, None]**2
+
+        # (x * dy + dx * y) * projected_up2d
+        # (B, N, 2, [2], K) x (B, N, 2) -> (B, N, 2, K)
+        J_proj2dist = torch.einsum("...Nijk,...Nj->...Nik", uv_J_offset2_dist + uv_offset_J_duv, projected_up2d)
+
+        # (B, N, 2, 2) * (B, N, 2, K) -> (B, N, 2, K)
+        J_dist = torch.matmul(J_norm2proj, J_proj2dist)
+        J.append(J_dist)
+
 
     n_params = sum(j.shape[-1] for j in J)
     return torch.cat(J, axis=-1).reshape(camera.shape[0], h, w, 2, n_params)
@@ -237,7 +253,7 @@ def J_latitude_field(
 
     # Backward
     J = []
-    J_norm2w_to_img = J_vecnorm(uv1)[..., :2]  # (..., N, 2)
+    J_norm2w_to_img = J_vecnorm(uv1)[..., :2]  # (..., N, 3, 2)
 
     ######################
     ## Gravity Jacobian ##
@@ -261,16 +277,22 @@ def J_latitude_field(
     J.append(J_f)
 
     ######################
-    ##### K1 Jacobian ####
+    ##### Distortion Parameters Jacobian ####
     ######################
 
     if hasattr(camera, "dist"):
-        J_w_to_img2k1 = camera.J_image2world(xy, "dist")  # (..., N, 2)
-        # (..., N, 2)
-        J_norm2k1 = torch.einsum("...Nij,...Nj->...Ni", J_norm2w_to_img, J_w_to_img2k1)
-        # (..., N, 1)
-        J_k1 = torch.einsum("...Ni,...i->...N", J_norm2k1, gravity.vec3d).unsqueeze(-1)
-        J.append(J_k1)
+        J_w_to_img2dist = camera.J_image2world(xy, "dist")  # (..., N, 2) for k1-only or (..., N, 2, K) for multiple ks
+        # Add an extra dimension for k1-only case
+        if len(J_w_to_img2dist.shape) == len(xy.shape):
+            J_w_to_img2dist = J_w_to_img2dist.unsqueeze(-1)
+
+        # (B, N, 3, 2) * (B, N, 2, K) -> (B, N, 3, K)
+        J_norm2dist = torch.matmul(J_norm2w_to_img, J_w_to_img2dist)  # (..., N, 3, K)
+
+        # (B, N, 3, K) * (3,) -> (B, N, K)
+        J_dist = torch.einsum("...Nij,...i->...Nj", J_norm2dist, gravity.vec3d)
+        J.append(J_dist)
+
 
     n_params = sum(j.shape[-1] for j in J)
     return torch.cat(J, axis=-1).reshape(camera.shape[0], h, w, 1, n_params)

--- a/geocalib/utils.py
+++ b/geocalib/utils.py
@@ -321,5 +321,5 @@ def print_calibration(results: Dict[str, torch.Tensor]) -> None:
     print(f"vFoV:  {vfov.item():.1f}° (± {rad2deg(results['vfov_uncertainty']).item():.1f})°")
     print(f"Focal: {camera.f[0, 1].item():.1f} px (± {results['focal_uncertainty'].item():.1f} px)")
 
-    if hasattr(camera, "k1"):
-        print(f"K1:    {camera.k1.item():.1f}")
+    if hasattr(camera, "dist"):
+        print(f"Dist:    {camera.dist[0, :camera.num_dist_params()].numpy().tolist()}")


### PR DESCRIPTION
This pull request add a "Radial" camera model which has k1,k2 distortion parameters into camera.py. Jacobians of this camera are implemented.

Several changes are made in lm_optimizer.py, perspective_fields.py, utils.py,  geocalib.py and cameras.py to support arbitrary number of distortion parameters, instead of only one k1 parameter.

The only thing I'm not sure about is the change in the Jacobian of the up vectors in perspective_fields.py. The old code seems to be heavily based on the assumption that there is only k1 and used some tricks to simplify the computation, like torch.diag_embed. My change is derived from Eq(9) from scratch, and it could produce the same result as the original code on the testing image. 

However, when I compare the values of the computed Jacobian (J_dist) and the original Jacobian (J_k1), I noticed their values become different after the first iteration, the direction seems correlated, for example (1.2, 1.0) vs (1.0, 0.8). I'm not sure if this is because there is a constant different between them which was discarded in the original implementation.

Could you help take a look at my implementation? I think this change can benefit the user community who wants to use more complicated cameras (SimpleRadial couldn't handle the fisheye examples).

Thank you so much!

Ruibin